### PR TITLE
Replace global Mutex<Hashmap> with DashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ once_cell = "1.10.0"
 serde = { version = "1", optional = true }
 phf_shared = "0.10"
 new_debug_unreachable = "1.0.2"
-parking_lot = "0.12"
+dashmap = "5.4.0"
 
 [[test]]
 name = "small-stack"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -15,9 +15,9 @@ fn main() {
             .filter(|interned_word| interned_word == &word)
             .count();
         if seen_before > 0 {
-            println!(r#"Seen the word "{}" {} times"#, word, seen_before);
+            println!(r#"Seen the word "{word}" {seen_before} times"#);
         } else {
-            println!(r#"Not seen the word "{}" before"#, word);
+            println!(r#"Not seen the word "{word}" before"#);
         }
         // We use the impl From<(Cow<'a, str>, or &'a str, or String) for Atom<Static> to intern a
         // new string

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2022-12-15"
+profile = "default"

--- a/src/dynamic_set.rs
+++ b/src/dynamic_set.rs
@@ -8,101 +8,61 @@
 // except according to those terms.
 
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 use std::borrow::Cow;
-use std::mem;
+use std::hash::{BuildHasherDefault, Hasher};
+
 use std::ptr::NonNull;
-use std::sync::atomic::AtomicIsize;
-use std::sync::atomic::Ordering::SeqCst;
-
-const NB_BUCKETS: usize = 1 << 12; // 4096
-const BUCKET_MASK: u32 = (1 << 12) - 1;
-
-pub(crate) struct Set {
-    buckets: Box<[Option<Box<Entry>>; NB_BUCKETS]>,
-}
 
 pub(crate) struct Entry {
     pub(crate) string: Box<str>,
     pub(crate) hash: u32,
-    pub(crate) ref_count: AtomicIsize,
-    next_in_bucket: Option<Box<Entry>>,
 }
-
-// Addresses are a multiples of this,
-// and therefore have have TAG_MASK bits unset, available for tagging.
-pub(crate) const ENTRY_ALIGNMENT: usize = 4;
 
 #[test]
 fn entry_alignment_is_sufficient() {
-    assert!(mem::align_of::<Entry>() >= ENTRY_ALIGNMENT);
+    // Addresses are a multiples of this,
+    // and therefore have have TAG_MASK bits unset, available for tagging.
+    const ENTRY_ALIGNMENT: usize = 4;
+    assert!(std::mem::align_of::<Entry>() >= ENTRY_ALIGNMENT);
 }
 
-pub(crate) static DYNAMIC_SET: Lazy<Mutex<Set>> = Lazy::new(|| {
-    Mutex::new({
-        type T = Option<Box<Entry>>;
-        let _static_assert_size_eq = std::mem::transmute::<T, usize>;
-        let vec = std::mem::ManuallyDrop::new(vec![0_usize; NB_BUCKETS]);
-        Set {
-            buckets: unsafe { Box::from_raw(vec.as_ptr() as *mut [T; NB_BUCKETS]) },
-        }
-    })
-});
+use dashmap::DashMap;
 
-impl Set {
-    pub(crate) fn insert(&mut self, string: Cow<str>, hash: u32) -> NonNull<Entry> {
-        let bucket_index = (hash & BUCKET_MASK) as usize;
-        {
-            let mut ptr: Option<&mut Box<Entry>> = self.buckets[bucket_index].as_mut();
+pub(crate) struct Set(DashMap<u32, Box<Entry>, BuildHasherDefault<IdentityHasher>>);
 
-            while let Some(entry) = ptr.take() {
-                if entry.hash == hash && *entry.string == *string {
-                    if entry.ref_count.fetch_add(1, SeqCst) > 0 {
-                        return NonNull::from(&mut **entry);
-                    }
-                    // Uh-oh. The pointer's reference count was zero, which means someone may try
-                    // to free it. (Naive attempts to defend against this, for example having the
-                    // destructor check to see whether the reference count is indeed zero, don't
-                    // work due to ABA.) Thus we need to temporarily add a duplicate string to the
-                    // list.
-                    entry.ref_count.fetch_sub(1, SeqCst);
-                    break;
-                }
-                ptr = entry.next_in_bucket.as_mut();
-            }
-        }
-        debug_assert!(mem::align_of::<Entry>() >= ENTRY_ALIGNMENT);
-        let string = string.into_owned();
-        let mut entry = Box::new(Entry {
-            next_in_bucket: self.buckets[bucket_index].take(),
-            hash,
-            ref_count: AtomicIsize::new(1),
-            string: string.into_boxed_str(),
-        });
-        let ptr = NonNull::from(&mut *entry);
-        self.buckets[bucket_index] = Some(entry);
+#[derive(Default)]
+pub struct IdentityHasher {
+    hash: u64,
+}
 
-        ptr
+impl Hasher for IdentityHasher {
+    fn write(&mut self, _: &[u8]) {
+        panic!("Invalid use of IdentityHasher")
     }
 
-    pub(crate) fn remove(&mut self, ptr: *mut Entry) {
-        let bucket_index = {
-            let value: &Entry = unsafe { &*ptr };
-            debug_assert!(value.ref_count.load(SeqCst) == 0);
-            (value.hash & BUCKET_MASK) as usize
-        };
+    fn write_u32(&mut self, n: u32) {
+        self.hash = n as u64
+    }
 
-        let mut current: &mut Option<Box<Entry>> = &mut self.buckets[bucket_index];
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+}
 
-        while let Some(entry_ptr) = current.as_mut() {
-            let entry_ptr: *mut Entry = &mut **entry_ptr;
-            if entry_ptr == ptr {
-                mem::drop(mem::replace(current, unsafe {
-                    (*entry_ptr).next_in_bucket.take()
-                }));
-                break;
+pub(crate) static DYNAMIC_SET: Lazy<Set> = Lazy::new(|| Set(DashMap::default()));
+
+impl Set {
+    pub(crate) fn insert(&self, string: Cow<str>, hash: u32) -> NonNull<Entry> {
+        match self.0.entry(hash) {
+            dashmap::mapref::entry::Entry::Occupied(s) => NonNull::from(&**s.get()),
+            dashmap::mapref::entry::Entry::Vacant(v) => {
+                let s = string.to_string().into_boxed_str();
+                let entry = Box::new(Entry { string: s, hash });
+                let ptr = NonNull::from(&*entry);
+                v.insert(entry);
+                ptr
             }
-            current = unsafe { &mut (*entry_ptr).next_in_bucket };
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,6 @@
 //!
 
 #![cfg_attr(test, deny(warnings))]
-
 // Types, such as Atom, that impl Hash must follow the hash invariant: if two objects match
 // with PartialEq, they must also have the same Hash. Clippy warns on types that derive one while
 // manually impl-ing the other, because it seems easy for the two to drift apart, causing the

--- a/src/trivial_impls.rs
+++ b/src/trivial_impls.rs
@@ -10,7 +10,7 @@
 use crate::{Atom, StaticAtomSet};
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 use std::fmt;
 
 impl<Static: StaticAtomSet> ::precomputed_hash::PrecomputedHash for Atom<Static> {
@@ -66,12 +66,6 @@ impl<Static: StaticAtomSet> fmt::Display for Atom<Static> {
 
 impl<Static: StaticAtomSet> AsRef<str> for Atom<Static> {
     fn as_ref(&self) -> &str {
-        self
-    }
-}
-
-impl<Static: StaticAtomSet> Borrow<str> for Atom<Static> {
-    fn borrow(&self) -> &str {
         self
     }
 }


### PR DESCRIPTION
This patch does the following:
* removes the global mutex which heavily impacts multi-threading
* removes dropping of interned strings

Note for swc: 

swc need to add back the dropping part otherwise applications may blow up their memory.

Impact on real project:

* Bottleneck on the global mutex is removed so we see a 10s -> 1s perf gain around string-cache.
* A full rspack build of an internal project reduced from 4.4s -> 3.2s (~30%)

![image](https://user-images.githubusercontent.com/1430279/218393076-bc4eec8c-d0a5-46a2-a7b6-3fa974628570.png)

