### PR TITLE
feat: use bucket mutex instead of global mutex for dynamic set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ once_cell = "1.10.0"
 serde = { version = "1", optional = true }
 phf_shared = "0.10"
 new_debug_unreachable = "1.0.2"
-parking_lot = "0.12"
 
 [[test]]
 name = "small-stack"

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -200,8 +200,7 @@ impl<'a, Static: StaticAtomSet> From<Cow<'a, str>> for Atom<Static> {
                     phantom: PhantomData,
                 }
             } else {
-                let ptr: std::ptr::NonNull<Entry> =
-                    DYNAMIC_SET.lock().insert(string_to_add, hash.g);
+                let ptr: std::ptr::NonNull<Entry> = DYNAMIC_SET.insert(string_to_add, hash.g);
                 let data = ptr.as_ptr() as u64;
                 debug_assert!(0 == data & TAG_MASK);
                 Atom {
@@ -237,9 +236,7 @@ impl<Static> Drop for Atom<Static> {
 
         // Out of line to guide inlining.
         fn drop_slow<Static>(this: &mut Atom<Static>) {
-            DYNAMIC_SET
-                .lock()
-                .remove(this.unsafe_data.get() as *mut Entry);
+            DYNAMIC_SET.remove(this.unsafe_data.get() as *mut Entry);
         }
     }
 }

--- a/src/dynamic_set.rs
+++ b/src/dynamic_set.rs
@@ -8,18 +8,18 @@
 // except according to those terms.
 
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 use std::borrow::Cow;
 use std::mem;
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicIsize;
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::Mutex;
 
 const NB_BUCKETS: usize = 1 << 12; // 4096
 const BUCKET_MASK: u32 = (1 << 12) - 1;
 
 pub(crate) struct Set {
-    buckets: Box<[Option<Box<Entry>>; NB_BUCKETS]>,
+    buckets: Box<[Mutex<Option<Box<Entry>>>]>,
 }
 
 pub(crate) struct Entry {
@@ -29,31 +29,26 @@ pub(crate) struct Entry {
     next_in_bucket: Option<Box<Entry>>,
 }
 
-// Addresses are a multiples of this,
-// and therefore have have TAG_MASK bits unset, available for tagging.
-pub(crate) const ENTRY_ALIGNMENT: usize = 4;
-
 #[test]
 fn entry_alignment_is_sufficient() {
+    // Addresses are a multiples of this,
+    // and therefore have have TAG_MASK bits unset, available for tagging.
+    const ENTRY_ALIGNMENT: usize = 4;
     assert!(mem::align_of::<Entry>() >= ENTRY_ALIGNMENT);
 }
 
-pub(crate) static DYNAMIC_SET: Lazy<Mutex<Set>> = Lazy::new(|| {
-    Mutex::new({
-        type T = Option<Box<Entry>>;
-        let _static_assert_size_eq = std::mem::transmute::<T, usize>;
-        let vec = std::mem::ManuallyDrop::new(vec![0_usize; NB_BUCKETS]);
-        Set {
-            buckets: unsafe { Box::from_raw(vec.as_ptr() as *mut [T; NB_BUCKETS]) },
-        }
-    })
+pub(crate) static DYNAMIC_SET: Lazy<Set> = Lazy::new(|| {
+    let buckets = (0..NB_BUCKETS).map(|_| Mutex::new(None)).collect();
+    Set { buckets }
 });
 
 impl Set {
-    pub(crate) fn insert(&mut self, string: Cow<str>, hash: u32) -> NonNull<Entry> {
+    pub(crate) fn insert(&self, string: Cow<str>, hash: u32) -> NonNull<Entry> {
         let bucket_index = (hash & BUCKET_MASK) as usize;
+        let mut vec = self.buckets[bucket_index].lock().unwrap();
+
         {
-            let mut ptr: Option<&mut Box<Entry>> = self.buckets[bucket_index].as_mut();
+            let mut ptr: Option<&mut Box<Entry>> = vec.as_mut();
 
             while let Some(entry) = ptr.take() {
                 if entry.hash == hash && *entry.string == *string {
@@ -71,28 +66,27 @@ impl Set {
                 ptr = entry.next_in_bucket.as_mut();
             }
         }
-        debug_assert!(mem::align_of::<Entry>() >= ENTRY_ALIGNMENT);
         let string = string.into_owned();
         let mut entry = Box::new(Entry {
-            next_in_bucket: self.buckets[bucket_index].take(),
+            next_in_bucket: vec.take(),
             hash,
             ref_count: AtomicIsize::new(1),
             string: string.into_boxed_str(),
         });
         let ptr = NonNull::from(&mut *entry);
-        self.buckets[bucket_index] = Some(entry);
-
+        *vec = Some(entry);
         ptr
     }
 
-    pub(crate) fn remove(&mut self, ptr: *mut Entry) {
+    pub(crate) fn remove(&self, ptr: *mut Entry) {
         let bucket_index = {
             let value: &Entry = unsafe { &*ptr };
             debug_assert!(value.ref_count.load(SeqCst) == 0);
             (value.hash & BUCKET_MASK) as usize
         };
 
-        let mut current: &mut Option<Box<Entry>> = &mut self.buckets[bucket_index];
+        let mut vec = self.buckets[bucket_index].lock().unwrap();
+        let mut current: &mut Option<Box<Entry>> = &mut vec;
 
         while let Some(entry_ptr) = current.as_mut() {
             let entry_ptr: *mut Entry = &mut **entry_ptr;

--- a/src/trivial_impls.rs
+++ b/src/trivial_impls.rs
@@ -10,7 +10,7 @@
 use crate::{Atom, StaticAtomSet};
 #[cfg(feature = "serde_support")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 use std::fmt;
 
 impl<Static: StaticAtomSet> ::precomputed_hash::PrecomputedHash for Atom<Static> {
@@ -70,11 +70,11 @@ impl<Static: StaticAtomSet> AsRef<str> for Atom<Static> {
     }
 }
 
-impl<Static: StaticAtomSet> Borrow<str> for Atom<Static> {
-    fn borrow(&self) -> &str {
-        self
-    }
-}
+// impl<Static: StaticAtomSet> Borrow<str> for Atom<Static> {
+// fn borrow(&self) -> &str {
+// self
+// }
+// }
 
 #[cfg(feature = "serde_support")]
 impl<Static: StaticAtomSet> Serialize for Atom<Static> {


### PR DESCRIPTION
This implementation uses bucket level mutex with linear probing.